### PR TITLE
Updated to support Output Sharpening arguments

### DIFF
--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -129,6 +129,13 @@ class ConvertImage(DirectoryProcessor):
                             dest="match_histogram",
                             default=False,
                             help="Use histogram matching. (Masked converter only)")
+        
+        parser.add_argument('-sh',
+                            type=str.lower,
+                            dest="sharpen_image",
+                            choices=["bsharpen", "gsharpen"],
+                            default="none",
+                            help="Use Sharpen Image - bSharpen = Box Blur, gSharpen = Gaussian Blur (Masked converter only)")
 
         parser.add_argument('-sm', '--smooth-mask',
                             action="store_true",
@@ -177,6 +184,7 @@ class ConvertImage(DirectoryProcessor):
             trainer=self.arguments.trainer,
             blur_size=self.arguments.blur_size,
             seamless_clone=self.arguments.seamless_clone,
+            sharpen_image=self.arguments.sharpen_image,
             mask_type=self.arguments.mask_type,
             erosion_kernel_size=self.arguments.erosion_kernel_size,
             match_histogram=self.arguments.match_histogram,


### PR DESCRIPTION
Two new types of output sharpening methods have been added.

One that deals with a Box Blur method and the other with a Gaussian Blur method.

Box Blur method can be called using argument '-sh bsharpen' --- This method is not dynamic and can produce strong sharpening on your images. Sometimes it can yield great results and sometimes entirely the opposite.

Gaussian Blur method can be called using argument '-sh gsharpen' --- This method is dynamic and tries to adjust to your data set. As a result, while the sharpening effect might not be as strong as bsharpen, it is bound to produce a more natural looking sharpened image.

By default the parameter is set to none which will not run any sharpening on your output.